### PR TITLE
Zip packaged module in dist, improve zip naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 ._*
 .DS_Store*
 npm-debug.log
+dist

--- a/appc.js
+++ b/appc.js
@@ -24,6 +24,7 @@ module.exports = {
     }
   },
   timodule: {
+    version: '1.0.0',
     apiversion: '1',
     guid: '35ebe7cc-0854-40f0-b67b-61014d67beaf',
     moduleid: 'ti.test',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^2.0.0",
+    "gulp-zip": "^3.2.0",
     "gulp-load-plugins": "^1.2.0",
     "gulp-mocha": "^2.2.0",
     "gulp-plumber": "^1.1.0",

--- a/test/module_test.js
+++ b/test/module_test.js
@@ -6,8 +6,8 @@ describe('module', () => {
 	before(() => {
 		global.Ti = {};
 		global.Ti.Android = {};
-		IOSView = require('../lib/ios/ti/test').View;
-		AndroidView = require('../lib/android/ti/test').View;
+		IOSView = require('../dist/lib/ios/ti/test').View;
+		AndroidView = require('../dist/lib/android/ti/test').View;
 	});
 
 	after(() => {


### PR DESCRIPTION
Names the packaged module like we used to `<module-id>-<module-platforms>-<module-version>.zip` and places it into `dist`.
